### PR TITLE
use `libc::ptp_sys_offset` and friends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ rust-version = "1.66"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = "0.2.145"
+libc = "0.2.165"


### PR DESCRIPTION
these have recently been added to libc

Not sure if this is relevant, but there are also a number of other very similar constants https://docs.rs/libc/latest/libc/constant.PTP_SYS_OFFSET2.html?search=const%3A%20PTP_SYS_OFFSET, should we be using any of those?